### PR TITLE
Getting uploader settiings from config.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 command-line-uploader
 =====================
+
+Upload your builds to Testfairy from command-line
+
+#Usage
+
+**Android**
+
+Complete the config.ini file with your Testfairy API key & Android sign keys. For testing i'll be using android default sign keys;
+```ini
+TESTFAIRY_API_KEY = 
+KEYSTORE =/Users/vruno/.android/debug.keystore
+STOREPASS =android
+ALIAS =androiddebugkey
+TESTER_GROUPS =
+```
+and run;
+```bash
+./testfairy-upload.sh /path/to/your/app.apk
+```
+
+
+**iOS**
+
+For iOS you just have to complete the config.ini file with your Testfairy API key and run
+```bash
+./testfairy-upload.sh /path/to/your/app.ipa
+```

--- a/config.ini
+++ b/config.ini
@@ -1,5 +1,5 @@
 TESTFAIRY_API_KEY = 
-KEYSTORE = ~/.android/debug.keystore
-STOREPASS = android
-ALIAS = 
-TESTER_GROUPS = 
+KEYSTORE =/Users/vruno/.android/debug.keystore
+STOREPASS =android
+ALIAS =androiddebugkey
+TESTER_GROUPS =

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,5 @@
+TESTFAIRY_API_KEY = 
+KEYSTORE = ~/.android/debug.keystore
+STOREPASS = android
+ALIAS = 
+TESTER_GROUPS = 

--- a/testfairy-upload-ios.sh
+++ b/testfairy-upload-ios.sh
@@ -8,7 +8,7 @@ TESTFAIRY_API_KEY=$(awk -F "=" '/TESTFAIRY_API_KEY/ {print $2}' config.ini)
 
 # Tester Groups that will be notified when the app is ready. Setup groups in your TestFairy account testers page.
 # This parameter is optional, leave empty if not required
-TESTER_GROUPS=$(awk -F "=" '/ALIAS/ {print $2}' config.ini)
+TESTER_GROUPS=$(awk -F "=" '/TESTER_GROUPS/ {print $2}' config.ini)
 
 # Should email testers about new version. Set to "off" to disable email notifications.
 NOTIFY="on"

--- a/testfairy-upload-ios.sh
+++ b/testfairy-upload-ios.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
 
-UPLOADER_VERSION=1.09
-# Put your TestFairy API_KEY here. Find it in your TestFairy account settings.
-TESTFAIRY_API_KEY=
+UPLOADER_VERSION=1.10
+
+# Get settings from config.ini file
+# Your TestFairy API_KEY. Find it in your TestFairy account settings.
+TESTFAIRY_API_KEY=$(awk -F "=" '/TESTFAIRY_API_KEY/ {print $2}' config.ini)
 
 # Tester Groups that will be notified when the app is ready. Setup groups in your TestFairy account testers page.
 # This parameter is optional, leave empty if not required
-TESTER_GROUPS=
+TESTER_GROUPS=$(awk -F "=" '/ALIAS/ {print $2}' config.ini)
 
 # Should email testers about new version. Set to "off" to disable email notifications.
 NOTIFY="on"

--- a/testfairy-upload.sh
+++ b/testfairy-upload.sh
@@ -2,17 +2,20 @@
 
 UPLOADER_VERSION=1.09
 
-# Put your TestFairy API_KEY here. Find it in your TestFairy account settings.
-TESTFAIRY_API_KEY=
+# Get settings from config.ini file
 
-# Your Keystore, Storepass and Alias, the ones you use to sign your app.
-KEYSTORE=
-STOREPASS=
-ALIAS=
+# Your TestFairy API_KEY. Find it in your TestFairy account settings.
+TESTFAIRY_API_KEY=$(awk -F "=" '/TESTFAIRY_API_KEY/ {print $2}' config.ini)
+
+# Your Keystore, Storepass and Alias, the ones you use to sign your app
+KEYSTORE=$(awk -F "=" '/KEYSTORE/ {print $2}' config.ini)
+STOREPASS=$(awk -F "=" '/STOREPASS/ {print $2}' config.ini)
+ALIAS=$(awk -F "=" '/ALIAS/ {print $2}' config.ini)
 
 # Tester Groups that will be notified when the app is ready. Setup groups in your TestFairy account testers page.
 # This parameter is optional, leave empty if not required
-TESTER_GROUPS=
+TESTER_GROUPS=$(awk -F "=" '/ALIAS/ {print $2}' config.ini)
+
 
 # Should email testers about new version. Set to "off" to disable email notifications.
 NOTIFY="on"

--- a/testfairy-upload.sh
+++ b/testfairy-upload.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 
-UPLOADER_VERSION=1.09
-
-# Get settings from config.ini file
+UPLOADER_VERSION=1.10
 
 # Your TestFairy API_KEY. Find it in your TestFairy account settings.
 TESTFAIRY_API_KEY=$(awk -F "=" '/TESTFAIRY_API_KEY/ {print $2}' config.ini)

--- a/testfairy-upload.sh
+++ b/testfairy-upload.sh
@@ -12,6 +12,7 @@ KEYSTORE=$(awk -F "=" '/KEYSTORE/ {print $2}' config.ini)
 STOREPASS=$(awk -F "=" '/STOREPASS/ {print $2}' config.ini)
 ALIAS=$(awk -F "=" '/ALIAS/ {print $2}' config.ini)
 
+
 # Tester Groups that will be notified when the app is ready. Setup groups in your TestFairy account testers page.
 # This parameter is optional, leave empty if not required
 TESTER_GROUPS=$(awk -F "=" '/ALIAS/ {print $2}' config.ini)
@@ -44,9 +45,11 @@ JARSIGNER=jarsigner
 
 SERVER_ENDPOINT=http://app.testfairy.com
 
+APK_FILENAME=$1
+
 usage() {
-	echo "Usage: testfairy-upload.sh APK_FILENAME"
-	echo
+	echo "Usage: testfairy-upload.sh $APK_FILENAME"
+	echo 
 }
 	
 verify_tools() {
@@ -118,7 +121,6 @@ fi
 verify_tools
 verify_settings
 
-APK_FILENAME=$1
 if [ ! -f "${APK_FILENAME}" ]; then
 	usage
 	echo "Can't find file: ${APK_FILENAME}"

--- a/testfairy-upload.sh
+++ b/testfairy-upload.sh
@@ -13,7 +13,7 @@ ALIAS=$(awk -F "=" '/ALIAS/ {print $2}' config.ini)
 
 # Tester Groups that will be notified when the app is ready. Setup groups in your TestFairy account testers page.
 # This parameter is optional, leave empty if not required
-TESTER_GROUPS=$(awk -F "=" '/ALIAS/ {print $2}' config.ini)
+TESTER_GROUPS=$(awk -F "=" '/TESTER_GROUPS/ {print $2}' config.ini)
 
 
 # Should email testers about new version. Set to "off" to disable email notifications.


### PR DESCRIPTION
Hey guys, I updated the `testfairy-upload-ios.sh`, `testfairy-upload.sh` to take the uploader settings from a `config.ini` file. This way a user can use TESTFAIRY_API_KEY from both files without having to edit both `.sh` files. 

I also added a bit of documentation in the `README.md`, showing default Android debug sign keys as example.
